### PR TITLE
Allow Dimmer brightness to be controlled independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,22 @@ Turning on is done by sending the following payload into the input. The light nu
 
 Like in the switch node you can replace on with turn and choose a value from the following: "toggle", "on", "off"
 
+You can also control the shelly state and brightness independently.
+
+```
+{
+on: true
+}
+```
+
+and
+
+```
+{
+brightness: 100
+}
+```
+
 Right after having sent the request to the shelly device a status request is done. The relays property of the response is output on output 1.
 
 If you only want to get the current status of the dimmer without turning on or off you should leave the msg.payload blank. This is useful, when you want to poll for the status cyclically.

--- a/shelly/99-shelly.js
+++ b/shelly/99-shelly.js
@@ -431,6 +431,9 @@ module.exports = function (RED) {
                 if (turn != undefined && brightness != undefined){
                   route = "/light/" + light + "?turn=" + turn + "&brightness=" + brightness;
                 }
+                else if (brightness != undefined){
+                    route = "/light/" + light + "?brightness=" + brightness;
+                }
                 else if (turn != undefined){
                     route = "/light/" + light + "?turn=" + turn;
                 }


### PR DESCRIPTION
This change will allow the node to adjust the brightness without having to specify `turn:  "on"` or `turn: "off"`.
For example `{brightness: 66}` will adjust the brightness regardless of whether the light in on or off.