### PR TITLE
Option to disable status requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directories
+node_modules/

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Turning on is done by sending the following payload into the input. The light nu
 
 Like in the switch node you can replace on with turn and choose a value from the following: "toggle", "on", "off"
 
-Right after having sent the request to the shelly device a status request is done. The relays property of the response is output on output 1.
+Right after having sent the request to the shelly device a status request is done. The relays property of the response is output on output 1.  
+This feature can optionally be disabled by unticking the `status` checkbox in the node configuration options.
 
 If you only want to get the current status of the dimmer without turning on or off you should leave the msg.payload blank. This is useful, when you want to poll for the status cyclically.
 

--- a/shelly/99-shelly.html
+++ b/shelly/99-shelly.html
@@ -392,7 +392,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-dimmerStat"><i class="fa fa-share"></i> Status</label>
-        <input type="checkbox" id="node-input-dimmerStat" style="display: inline-block; width: auto; vertical-align: top;"> Enable status report
+        <input type="checkbox" id="node-input-dimmerStat" style="display: inline-block; width: auto; vertical-align: top"> Enable status output after each command
     </div>
 </script>
 
@@ -404,6 +404,7 @@
     <p>Description of the device.</p>
     <p>User is optional and must only be set if security is enabled.</p>
     <p>Password is optional and must only be set if security is enabled.</p>
+    <p>Status enables a node status payload following every command.</p>
 
     <h3>Inputs</h3>
     <p>Empty payload for getting the status. Or the following object for turning the dimmer on or off:</p>

--- a/shelly/99-shelly.html
+++ b/shelly/99-shelly.html
@@ -351,7 +351,7 @@
         defaults: {
             hostname: { value:"", required:true },
             description: { value:"" },
-	    dimmerStat: { value: false, required: false }
+	    dimmerStat: { value: true }
         },
         credentials: {
             username: { type: "text" },
@@ -391,8 +391,8 @@
         <input type="text" id="node-input-password" placeholder="Enter the password here (optional))">
     </div>
     <div class="form-row">
-        <label for="node-input-statusRep"><i class="fa fa-cogs"></i> Status</label>
-        <input type="checkbox" id="node-input-dimmerStat" style="display: inline-block; width: auto; vertical-align: top;"> Status Report
+        <label for="node-input-dimmerStat"><i class="fa fa-share"></i> Status</label>
+        <input type="checkbox" id="node-input-dimmerStat" style="display: inline-block; width: auto; vertical-align: top;"> Enable status report
     </div>
 </script>
 

--- a/shelly/99-shelly.html
+++ b/shelly/99-shelly.html
@@ -350,7 +350,8 @@
         color: '#319DD7',
         defaults: {
             hostname: { value:"", required:true },
-            description: { value:"" }
+            description: { value:"" },
+	    dimmerStat: { value: false, required: false }
         },
         credentials: {
             username: { type: "text" },
@@ -388,6 +389,10 @@
     <div class="form-row">
         <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
         <input type="text" id="node-input-password" placeholder="Enter the password here (optional))">
+    </div>
+    <div class="form-row">
+        <label for="node-input-statusRep"><i class="fa fa-cogs"></i> Status</label>
+        <input type="checkbox" id="node-input-dimmerStat" style="display: inline-block; width: auto; vertical-align: top;"> Status Report
     </div>
 </script>
 

--- a/shelly/99-shelly.js
+++ b/shelly/99-shelly.js
@@ -357,6 +357,7 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, config);
         var node = this;
         node.hostname = config.hostname;
+	node.dimmerStat = config.dimmerStat || false;
 
         /* node.shellyInfo
         GET /shelly
@@ -438,13 +439,15 @@ module.exports = function (RED) {
 
             if(route){
                 shellyGet(route, node, function(result) {
-                    shellyGet('/status', node, function(result) {
-                        var status = JSON.parse(result);
-                        msg.status = status;
-                        msg.payload = status.lights;
-                        node.send([msg]);
-                    });
-                });
+		    if (!node.dimmerStat) {
+			shellyGet('/status', node, function(result) {
+                          var status = JSON.parse(result);
+                          msg.status = status;
+                          msg.payload = status.lights;
+                          node.send([msg]);
+			});
+		    }
+		});
             }
             else{
                 shellyGet('/status', node, function(result) {

--- a/shelly/99-shelly.js
+++ b/shelly/99-shelly.js
@@ -432,6 +432,9 @@ module.exports = function (RED) {
                 if (turn != undefined && brightness != undefined){
                   route = "/light/" + light + "?turn=" + turn + "&brightness=" + brightness;
                 }
+                else if (brightness != undefined){
+		  route = "/light/" + light + "?brightness=" + brightness;
+                }
                 else if (turn != undefined){
                     route = "/light/" + light + "?turn=" + turn;
                 }

--- a/shelly/99-shelly.js
+++ b/shelly/99-shelly.js
@@ -439,7 +439,7 @@ module.exports = function (RED) {
 
             if(route){
                 shellyGet(route, node, function(result) {
-		    if (!node.dimmerStat) {
+		    if (node.dimmerStat) {
 			shellyGet('/status', node, function(result) {
                           var status = JSON.parse(result);
                           msg.status = status;

--- a/shelly/99-shelly.js
+++ b/shelly/99-shelly.js
@@ -432,9 +432,6 @@ module.exports = function (RED) {
                 if (turn != undefined && brightness != undefined){
                   route = "/light/" + light + "?turn=" + turn + "&brightness=" + brightness;
                 }
-                else if (brightness != undefined){
-		  route = "/light/" + light + "?brightness=" + brightness;
-                }
                 else if (turn != undefined){
                     route = "/light/" + light + "?turn=" + turn;
                 }


### PR DESCRIPTION
This PR introduces a checkbox in the dimmer node config which enables users to disable/enable status reports being produced after each command.
The default state of the checkbox is 'enabled' to maintain compatibility with existing flows.
If unchecked, a status report can still be requested by injecting a blank msg.payload (unchanged).

The reason for introducing this is to resolve issue https://github.com/windkh/node-red-contrib-shelly/issues/21