### PR TITLE
Fix too many calls due to power updates

### DIFF
--- a/shelly/scripts/button.script
+++ b/shelly/scripts/button.script
@@ -22,7 +22,8 @@ Shelly.addEventHandler(
    function (event, userdata) {
            if (typeof event.info.event !== 'undefined') {
                let eventType = event.info.event;
-               if(eventType !== 'btn_up' && eventType !== 'btn_down'){
+               if(eventType !== 'power_update' && eventType !== 'current_update' &&
+                  eventType !== 'btn_up' && eventType !== 'btn_down'){
                    CallNodeRed(event)
                }
            }


### PR DESCRIPTION
Fixes issue #142 where the call back script would crash on Shelly PLUS 2PM devices because after pressing a button the device reports power and current updates with a high frequency - each triggering a CallNodeRed function call.