### PR TITLE
ci: add the standards check, gate pre-releases, drop --test-force-exit

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,11 @@ jobs:
                   node-version: 20
                   registry-url: https://registry.npmjs.org/
             - run: npm ci
-            - run: npm publish
+            # A GitHub release flagged "pre-release" goes to the `beta` dist-tag, so users
+            # on Manage Palette — which tracks `latest` — are not auto-upgraded onto an
+            # unproven build. A plain `npm publish` would move `latest` to the beta and
+            # push it to every install; `latest` cannot be walked back to an earlier
+            # version by publishing, only by a separate dist-tag change.
+            - run: npm publish ${{ github.event.release.prerelease && '--tag beta' || '' }}
               env:
                   NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/standards-check.yml
+++ b/.github/workflows/standards-check.yml
@@ -1,0 +1,26 @@
+# Synced into target repos by `nrstd sync` as .github/workflows/standards-check.yml.
+# Fails CI if the repo drifts from the shared standard. Tool-neutral (no AI).
+# `nrstd audit` exits non-zero below 10/10, so a repo adopting this should run
+# `nrstd sync --write` first — otherwise its next push goes red on pre-existing drift.
+name: Standards check
+on:
+    push:
+        branches: [master, main]
+    pull_request:
+permissions:
+    contents: read
+jobs:
+    standards:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
+              with:
+                  node-version: 20.x
+            # Resolved from Git, not the npm registry: this package is deliberately
+            # unpublished (README "Install", option B), so a bare
+            # `npx --yes node-red-standards` fails every run with E404 before it can
+            # audit anything — which reads as drift when it is really a missing
+            # package. The repo is public, so no token is needed. If it is ever
+            # published, the short form becomes available and this can go back.
+            - run: npx --yes github:windkh/node-red-standards audit

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "prepare": "husky",
         "lint": "eslint .",
         "postlint": "echo ✅ lint valid",
-        "test": "node --test --test-force-exit --test-timeout=30000 --test-concurrency=1",
+        "test": "node --test --test-timeout=30000 --test-concurrency=1",
         "test:watch": "node --test --watch",
         "coverage": "c8 npm test",
         "coverage:check": "c8 --check-coverage npm test",


### PR DESCRIPTION
Picks up the [node-red-standards 0.4.1](https://github.com/windkh/node-red-standards/commit/b0ab6cf) fixes.

### `standards-check.yml` (new)

The weekly rollout has been trying to add this in #288, but its copy came from the broken template: it ran `npx --yes node-red-standards audit`, the published-name form for a package that is deliberately unpublished, so it failed with `E404` on every run before it could audit anything. This copy resolves the CLI from Git instead.

`nrstd audit` reports **10/10** for this repo, so the check goes green rather than red. **#288 is redundant once this lands.**

### `npm-publish.yml`

Publish with `--tag beta` when the GitHub release is flagged *pre-release*. Previously a pre-release would have gone to `latest` and auto-upgraded every Manage Palette user onto an unproven build — and `latest` cannot be walked back by publishing, only by a separate dist-tag change.

The rest of this workflow already had the full gate (`lint`, `format:check`, `test`) and `needs: build`, so it is left alone. Node stays on 20: this package declares `engines >= 20`, so the standard's `22.x` pin — which exists for repos that raised their floor — is not needed here.

### `package.json`

Drops `--test-force-exit` from the test script. It calls `process.exit()` as soon as the last test finishes, racing libuv's teardown of keep-alive sockets and mock servers; on Windows that aborts the process *after* the results are in, so a whole file reports as failed while every test in it passed. Leaving it off also proves the suite leaks no handles.

Verified locally before changing it: **279 pass, exit 0, no hang.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)