### PR TITLE
ci: declare least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,23 +1,24 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Node.js CI
 
 on:
     push:
-        branches: [master]
+        branches: [master, main]
     pull_request:
-        branches: [master]
+        branches: [master, main]
+
+# Least privilege for GITHUB_TOKEN. Without an explicit block a workflow inherits the
+# repository default, which on many repos is read *and write* to everything -- flagged by
+# CodeQL as actions/missing-workflow-permissions. This job only reads the checkout; the
+# artifact upload authenticates with the runtime token, not GITHUB_TOKEN.
+permissions:
+    contents: read
 
 jobs:
     build:
         runs-on: ubuntu-latest
-
         strategy:
             matrix:
                 node-version: [20.x, 22.x]
-                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
         steps:
             - uses: actions/checkout@v7
             - name: Use Node.js ${{ matrix.node-version }}
@@ -30,10 +31,21 @@ jobs:
             - run: npm run format:check
             - run: npm test
             - run: npm run coverage:check
+            # Uploaded from one matrix leg only — the report is identical across them, and
+            # two legs writing the same artifact name is an error. Makes a coverage
+            # regression inspectable from the failing run instead of only reproducible locally.
             - name: Upload coverage report
               if: matrix.node-version == '22.x'
               uses: actions/upload-artifact@v7
               with:
                   name: coverage-report
-                  path: coverage/
+                  # Only the readable report, not all of `coverage/`. c8 also writes its
+                  # raw V8 dump to coverage/tmp, which is ~97% of the bytes and inspectable
+                  # by nothing — measured at 23 MB of tmp against a 647 kB report. Uploading
+                  # the directory ships that dead weight on every run for the whole
+                  # retention window, and the step exists to make a failure *readable*.
+                  # Requires c8 to emit a report: `"reporter": ["text", "lcov"]`.
+                  path: |
+                      coverage/lcov-report
+                      coverage/lcov.info
                   retention-days: 14

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,12 @@ on:
             - 'v*'
             - 'V*'
 
+# Least privilege for GITHUB_TOKEN, declared at the top so it covers every job. The one job
+# that needs more (github-release, which creates the release) raises it to `contents: write`
+# for itself. npm authentication is a separate secret and is unaffected by this.
+permissions:
+    contents: read
+
 jobs:
     # The same gate as CI, re-run here on purpose, and on the same matrix. A release is cut from
     # a tag, and nothing guarantees that tag points at a commit CI ever saw -- a tag can be


### PR DESCRIPTION
Brings both workflows up to node-red-standards 0.6.1. This repo and `node-red-contrib-ntrip` are the two that were left behind when the permissions pass went through the others — and the reason is worth naming: they are exactly the two repos **without code scanning enabled**. The same gap existed here, nothing reported it.

## 1. `permissions: contents: read` in both workflows

A workflow with no `permissions:` block inherits the repository default, which on many repos is read *and write* to everything — so a compromised action or a malicious dependency in a CI run gets a token that can push commits. Both files now start from `contents: read`; in `npm-publish.yml` the one job that needs more (`github-release`, which creates the release) raises itself to `contents: write`. npm authentication is a separate secret and is unaffected.

In the four repos that do have code scanning this closed 13 `actions/missing-workflow-permissions` alerts.

## 2. The coverage artifact stops shipping c8's raw V8 dump

Not something I went looking for — it turned up while diffing `node.js.yml` against the template. This repo never received the 0.4.2 fix:

```diff
-                  path: coverage/
+                  path: |
+                      coverage/lcov-report
+                      coverage/lcov.info
```

`coverage/` also contains `coverage/tmp`, c8's raw V8 output, which is about **97% of the bytes** — measured elsewhere at 23 MB of `tmp` against a 647 kB report. Every CI run has been uploading that and holding it for the full 14-day retention window, and nothing can read it. The step exists to make a coverage failure *inspectable*, so it should upload the readable half.

The `c8` block here already emits `lcov` (`reporter: ["text", "html", "lcov"]`), so both paths are produced.

## 3. Cosmetics

`branches: [master]` → `[master, main]` (the template covers both; harmless here) and the GitHub starter-workflow comments come out.

Verified locally: `npm run lint`, `npm run format:check` and all 290 tests pass; both files parse as YAML.
