### PR TITLE
fix: digest authentication against firmware 2.0.0 (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [11.12.2] - 2026-08-27
+
+### Digest auth works again on firmware 2.0.0 - [#296](https://github.com/windkh/node-red-contrib-shelly/issues/296)
+
+Authenticated requests to gen 2+ devices running firmware 2.0.0 failed with `Unauthorized /rpc/Shelly.GetStatus`, while the same credentials worked from `curl --anyauth`.
+
+The digest handshake in [`shelly/lib/shelly.js`](shelly/lib/shelly.js) sends every request unauthenticated first and builds the `Authorization` header from the fresh nonce in the 401 challenge. The nonce is therefore never reused — but the nonce count came from a module-global counter that was pre-incremented on each call and shared across every device in the runtime. The first authenticated request after a restart announced `nc=00000002` for a nonce it was using for the first time, and it climbed from there.
+
+Firmware 2.0.0 implements RFC 7616 and tracks the count per nonce, so it rejects anything but `00000001`. Earlier firmware ignored the field, which is why this went unnoticed. The counter is gone; `nc` is now the constant `00000001`, which is what a fresh nonce means and is equally correct on older firmware.
+
+Diagnosis and fix contributed by [eisenluk](https://github.com/eisenluk).
+
 ## [11.12.1] - 2026-08-19
 
 ### Internals: the cloud transport left the RED closure — nothing changes for flows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [11.12.3] - 2026-08-27
+
+### The digest challenge is parsed properly, and a malformed one says so
+
+Follow-up to [#296](https://github.com/windkh/node-red-contrib-shelly/issues/296), hardening the other half of the same handshake.
+
+The `WWW-Authenticate` challenge was parsed by splitting the header on `', '` and then splitting each parameter on **every** `=`, keeping only the second field. Three assumptions came with that, none of them guaranteed by RFC 7235: that no value contains `=`, that the whitespace after the separating comma is always there, and that no quoted value contains a comma. A base64 nonce lost everything from its `=` padding onward; a challenge written `qop="auth",realm="x"` collapsed into a single token and left `realm` and `nonce` undefined.
+
+Undefined values were then hashed as the literal string `undefined`, so the node sent a syntactically valid but meaningless `Authorization` header, the device answered 401, and the user was told `Unauthorized /rpc/Shelly.GetStatus` — the same message a wrong password produces, and the same one #296 produced. Nothing pointed at the header.
+
+The challenge is now parsed with a tokenizer that understands quoted strings, and a challenge carrying no realm or nonce raises `Malformed digest challenge, no realm or nonce in: <header>` rather than proceeding with a hash of nothing. Current firmware sends a numeric nonce and the conventional `', '` separator, so no device in the field was affected — this closes the gap before one is.
+
 ## [11.12.2] - 2026-08-27
 
 ### Digest auth works again on firmware 2.0.0 - [#296](https://github.com/windkh/node-red-contrib-shelly/issues/296)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [11.12.3] - 2026-08-27
 
-### The digest challenge is parsed properly, and a malformed one says so
-
-Follow-up to [#296](https://github.com/windkh/node-red-contrib-shelly/issues/296), hardening the other half of the same handshake.
-
-The `WWW-Authenticate` challenge was parsed by splitting the header on `', '` and then splitting each parameter on **every** `=`, keeping only the second field. Three assumptions came with that, none of them guaranteed by RFC 7235: that no value contains `=`, that the whitespace after the separating comma is always there, and that no quoted value contains a comma. A base64 nonce lost everything from its `=` padding onward; a challenge written `qop="auth",realm="x"` collapsed into a single token and left `realm` and `nonce` undefined.
-
-Undefined values were then hashed as the literal string `undefined`, so the node sent a syntactically valid but meaningless `Authorization` header, the device answered 401, and the user was told `Unauthorized /rpc/Shelly.GetStatus` — the same message a wrong password produces, and the same one #296 produced. Nothing pointed at the header.
-
-The challenge is now parsed with a tokenizer that understands quoted strings, and a challenge carrying no realm or nonce raises `Malformed digest challenge, no realm or nonce in: <header>` rather than proceeding with a hash of nothing. Current firmware sends a numeric nonce and the conventional `', '` separator, so no device in the field was affected — this closes the gap before one is.
-
-## [11.12.2] - 2026-08-27
-
 ### Digest auth works again on firmware 2.0.0 - [#296](https://github.com/windkh/node-red-contrib-shelly/issues/296)
 
 Authenticated requests to gen 2+ devices running firmware 2.0.0 failed with `Unauthorized /rpc/Shelly.GetStatus`, while the same credentials worked from `curl --anyauth`.
@@ -25,6 +13,16 @@ The digest handshake in [`shelly/lib/shelly.js`](shelly/lib/shelly.js) sends eve
 Firmware 2.0.0 implements RFC 7616 and tracks the count per nonce, so it rejects anything but `00000001`. Earlier firmware ignored the field, which is why this went unnoticed. The counter is gone; `nc` is now the constant `00000001`, which is what a fresh nonce means and is equally correct on older firmware.
 
 Diagnosis and fix contributed by [eisenluk](https://github.com/eisenluk).
+
+### The digest challenge is parsed properly, and a malformed one says so
+
+Follow-up to [#296](https://github.com/windkh/node-red-contrib-shelly/issues/296), hardening the other half of the same handshake.
+
+The `WWW-Authenticate` challenge was parsed by splitting the header on `', '` and then splitting each parameter on **every** `=`, keeping only the second field. Three assumptions came with that, none of them guaranteed by RFC 7235: that no value contains `=`, that the whitespace after the separating comma is always there, and that no quoted value contains a comma. A base64 nonce lost everything from its `=` padding onward; a challenge written `qop="auth",realm="x"` collapsed into a single token and left `realm` and `nonce` undefined.
+
+Undefined values were then hashed as the literal string `undefined`, so the node sent a syntactically valid but meaningless `Authorization` header, the device answered 401, and the user was told `Unauthorized /rpc/Shelly.GetStatus` — the same message a wrong password produces, and the same one #296 produced. Nothing pointed at the header.
+
+The challenge is now parsed with a tokenizer that understands quoted strings, and a challenge carrying no realm or nonce raises `Malformed digest challenge, no realm or nonce in: <header>` rather than proceeding with a hash of nothing. Current firmware sends a numeric nonce and the conventional `', '` separator, so no device in the field was affected — this closes the gap before one is.
 
 ## [11.12.1] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ If you want to support this free project. Any help is welcome. You can donate by
 - MichaelEFlip for improving the readme
 - Solarer for fixing script overload
 - prpr19xx for adding exception handling to callback script
+- eisenluk for finding and fixing the digest authentication failure on firmware 2.0.0 see issue #296
 
 # 👥 Contributors
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-shelly",
-    "version": "11.12.2",
+    "version": "11.12.3",
     "description": "Shelly nodes.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-shelly",
-    "version": "11.12.1",
+    "version": "11.12.2",
     "description": "Shelly nodes.",
     "node-red": {
         "version": ">=3.0.0",

--- a/shelly/lib/shelly.js
+++ b/shelly/lib/shelly.js
@@ -5,8 +5,6 @@ const crypto = require('crypto');
 
 const axios = require('axios').default;
 
-let nonceCount = 1;
-
 // gets all IP addresses: https://stackoverflow.com/questions/3653065/get-local-ip-address-in-node-js?page=2&tab=scoredesc#tab-top
 function getIPAddresses() {
     const ipAddresses = [];
@@ -106,7 +104,6 @@ function getDigestAuthorization(response, credentials, config) {
     const propertiesArray = authDetails.map((v) => v.split('='));
     const properties = new Map(propertiesArray.map((obj) => [obj[0], obj[1]]));
 
-    nonceCount++; // global counter
     const url = config.url;
     const method = config.method;
 
@@ -120,7 +117,10 @@ function getDigestAuthorization(response, credentials, config) {
     const ha1 = sha256(ha1String);
     const ha2String = method + ':' + url;
     const ha2 = sha256(ha2String);
-    const nc = ('00000000' + nonceCount).slice(-8);
+    // Every digest request starts with an unauthenticated call and gets a fresh nonce back in the
+    // 401 challenge, so the nonce count is always the first use of that nonce. Firmware 2.0.0 tracks
+    // the count per nonce (RFC 7616) and rejects anything but 00000001 here. See #296.
+    const nc = '00000001';
     const nonce = utils.replace(properties.get('nonce'), /"/g, '');
     const cnonce = crypto.randomBytes(24).toString('hex');
     const responseString = ha1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + 'auth' + ':' + ha2;

--- a/shelly/lib/shelly.js
+++ b/shelly/lib/shelly.js
@@ -97,20 +97,32 @@ function sha256(str) {
     return result;
 }
 
-// see https://shelly-api-docs.shelly.cloud/gen2/General/Authentication
-// see https://github.com/axios/axios/issues/686
-function getDigestAuthorization(response, credentials, config) {
-    const authDetails = response.headers['www-authenticate'].split(', ');
-    const propertiesArray = authDetails.map((v) => v.split('='));
-    const properties = new Map(propertiesArray.map((obj) => [obj[0], obj[1]]));
+// Parses the parameters of a WWW-Authenticate challenge into a map, with quotes already stripped.
+// The challenge is a comma-separated list of name=value pairs whose values may be quoted strings
+// (RFC 7235), so neither splitting on ', ' nor on every '=' holds up: the whitespace after the comma
+// is optional, a base64 nonce carries '=' padding, and a quoted value may contain a comma itself.
+function parseAuthenticateHeader(header) {
+    const parameters = new Map();
+    const matcher = /([A-Za-z0-9_-]+)\s*=\s*(?:"([^"]*)"|([^\s,]*))/g;
 
+    let match = matcher.exec(header);
+    while (match !== null) {
+        const value = match[2] !== undefined ? match[2] : match[3];
+        parameters.set(match[1], value);
+        match = matcher.exec(header);
+    }
+
+    return parameters;
+}
+
+// Builds the Authorization header value answering a digest challenge.
+function buildDigestAuthorization(realm, nonce, credentials, config) {
     const url = config.url;
     const method = config.method;
 
     // let algorithm = properties.get('algorithm'); // TODO: check if it is still SHA-256
     const username = credentials.username;
     const password = credentials.password;
-    const realm = utils.replace(properties.get('realm'), /"/g, '');
     const authParts = [username, realm, password];
 
     const ha1String = authParts.join(':');
@@ -121,7 +133,6 @@ function getDigestAuthorization(response, credentials, config) {
     // 401 challenge, so the nonce count is always the first use of that nonce. Firmware 2.0.0 tracks
     // the count per nonce (RFC 7616) and rejects anything but 00000001 here. See #296.
     const nc = '00000001';
-    const nonce = utils.replace(properties.get('nonce'), /"/g, '');
     const cnonce = crypto.randomBytes(24).toString('hex');
     const responseString = ha1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + 'auth' + ':' + ha2;
     const responseHash = sha256(responseString);
@@ -143,6 +154,27 @@ function getDigestAuthorization(response, credentials, config) {
         ', response="' +
         responseHash +
         '", algorithm=SHA-256';
+    return authorization;
+}
+
+// see https://shelly-api-docs.shelly.cloud/gen2/General/Authentication
+// see https://github.com/axios/axios/issues/686
+function getDigestAuthorization(response, credentials, config) {
+    const header = response.headers['www-authenticate'];
+    const properties = parseAuthenticateHeader(header);
+    const realm = properties.get('realm');
+    const nonce = properties.get('nonce');
+
+    let authorization;
+    if (realm !== undefined && nonce !== undefined) {
+        authorization = buildDigestAuthorization(realm, nonce, credentials, config);
+    } else {
+        // Hashing an absent realm or nonce produces a well-formed header the device rejects, and the
+        // retry then failed as a bare "Unauthorized <route>" — the same message a wrong password
+        // gives, which is what made #296 take a firmware bisect to find. Name the real cause instead.
+        throw new Error('Malformed digest challenge, no realm or nonce in: ' + header);
+    }
+
     return authorization;
 }
 

--- a/test/unit/transport.test.js
+++ b/test/unit/transport.test.js
@@ -109,7 +109,8 @@ describe('shellyRequestAsync — Digest auth (gen 2+) 401 retry', () => {
         });
 
         // Second call: must carry an Authorization: Digest ... header. Match
-        // partial values — exact nc / cnonce are nondeterministic.
+        // partial values — the exact cnonce is nondeterministic, but nc is not:
+        // the nonce is fresh, so it is always its first use.
         nock(URL)
             .get('/rpc/Switch.GetStatus')
             .matchHeader('Authorization', (val) => {
@@ -121,7 +122,7 @@ describe('shellyRequestAsync — Digest auth (gen 2+) 401 retry', () => {
                     val.includes('uri="/rpc/Switch.GetStatus"') &&
                     val.includes('qop=auth') &&
                     val.includes('algorithm=SHA-256') &&
-                    /nc=[0-9a-f]{8}/.test(val) &&
+                    val.includes('nc=00000001') &&
                     /response="[a-f0-9]+"/.test(val)
                 );
             })
@@ -138,6 +139,39 @@ describe('shellyRequestAsync — Digest auth (gen 2+) 401 retry', () => {
         });
 
         assert.deepEqual(result, { id: 0, output: true });
+    });
+
+    // Firmware 2.0.0 validates the nonce count per nonce (RFC 7616). A module-global counter that
+    // survived between requests sent 00000002, 00000003, … against nonces that were each brand new,
+    // and every authenticated call failed with "Unauthorized". See #296.
+    it('sends nc=00000001 on every request, not an ever-increasing counter', async () => {
+        const sentCounts = [];
+
+        for (const nonce of ['first-nonce', 'second-nonce']) {
+            nock(URL)
+                .get('/rpc/Shelly.GetStatus')
+                .reply(401, 'Unauthorized', {
+                    'www-authenticate':
+                        'Digest qop="auth", realm="shellypmmini", nonce="' + nonce + '", algorithm=SHA-256',
+                });
+
+            nock(URL)
+                .get('/rpc/Shelly.GetStatus')
+                .matchHeader('Authorization', (val) => {
+                    sentCounts.push(/nc=([0-9]{8})/.exec(val)[1]);
+                    return true;
+                })
+                .reply(200, { ok: true });
+
+            await shellyRequestAsync(axios, 'GET', '/rpc/Shelly.GetStatus', null, null, {
+                hostname: HOST,
+                authType: 'Digest',
+                username: 'admin',
+                password: 'topsecret',
+            });
+        }
+
+        assert.deepEqual(sentCounts, ['00000001', '00000001']);
     });
 
     it('throws when the digest retry itself is rejected with a non-200, non-401 status', async () => {

--- a/test/unit/transport.test.js
+++ b/test/unit/transport.test.js
@@ -2,6 +2,7 @@ const { describe, it, beforeEach, afterEach, after } = require('node:test');
 const assert = require('node:assert/strict');
 const nock = require('nock');
 const axios = require('axios').default;
+const crypto = require('node:crypto');
 
 const { shellyRequestAsync } = require('../../shelly/lib/shelly.js');
 
@@ -192,6 +193,93 @@ describe('shellyRequestAsync — Digest auth (gen 2+) 401 retry', () => {
                 password: 'x',
             }),
             /forbidden/
+        );
+    });
+});
+
+describe('shellyRequestAsync — Digest challenge parsing', () => {
+    const CREDENTIALS = { hostname: HOST, authType: 'Digest', username: 'admin', password: 'topsecret' };
+
+    // Drives one full 401 -> retry cycle against the given challenge and hands back the
+    // Authorization header the device would have received.
+    async function captureAuthorization(challenge) {
+        let sent;
+
+        nock(URL).get('/rpc/Shelly.GetStatus').reply(401, 'Unauthorized', { 'www-authenticate': challenge });
+        nock(URL)
+            .get('/rpc/Shelly.GetStatus')
+            .matchHeader('Authorization', (val) => {
+                sent = val;
+                return true;
+            })
+            .reply(200, { ok: true });
+
+        await shellyRequestAsync(axios, 'GET', '/rpc/Shelly.GetStatus', null, null, CREDENTIALS);
+
+        return sent;
+    }
+
+    it('reads realm and nonce from the challenge Shelly sends today', async () => {
+        const sent = await captureAuthorization(
+            'Digest qop="auth", realm="shellypmmini-abc", nonce="1234567890", algorithm=SHA-256'
+        );
+
+        assert.match(sent, /realm="shellypmmini-abc"/);
+        assert.match(sent, /nonce="1234567890"/);
+    });
+
+    // Splitting each parameter on every '=' and keeping field [1] truncated the value at its first
+    // '=' — a base64 nonce lost its padding, so the hash was computed over a different nonce than
+    // the device had issued and the retry came back Unauthorized.
+    it('keeps a base64 nonce whose padding contains =', async () => {
+        const sent = await captureAuthorization(
+            'Digest qop="auth", realm="shellypmmini-abc", nonce="YWJjZGVmZw==", algorithm=SHA-256'
+        );
+
+        assert.match(sent, /nonce="YWJjZGVmZw=="/);
+
+        // The echoed nonce alone would not prove the hash used it, so recompute the response the way
+        // the device does and require a match.
+        const sha256 = (str) => crypto.createHash('sha256').update(str).digest('hex');
+        const cnonce = /cnonce="([a-f0-9]+)"/.exec(sent)[1];
+        const ha1 = sha256('admin:shellypmmini-abc:topsecret');
+        const ha2 = sha256('GET:/rpc/Shelly.GetStatus');
+        const expected = sha256(ha1 + ':YWJjZGVmZw==:00000001:' + cnonce + ':auth:' + ha2);
+
+        assert.match(sent, new RegExp('response="' + expected + '"'));
+    });
+
+    // RFC 7235 makes the whitespace after the separating comma optional. Splitting on the literal
+    // ', ' collapsed such a challenge into a single token, leaving realm and nonce undefined.
+    it('accepts a challenge with no whitespace after the commas', async () => {
+        const sent = await captureAuthorization(
+            'Digest qop="auth",realm="shellypmmini-abc",nonce="1234567890",algorithm=SHA-256'
+        );
+
+        assert.match(sent, /realm="shellypmmini-abc"/);
+        assert.match(sent, /nonce="1234567890"/);
+    });
+
+    it('keeps a quoted realm that contains a comma', async () => {
+        const sent = await captureAuthorization(
+            'Digest qop="auth", realm="Shelly, Gen3", nonce="1234567890", algorithm=SHA-256'
+        );
+
+        assert.match(sent, /realm="Shelly, Gen3"/);
+        assert.match(sent, /nonce="1234567890"/);
+    });
+
+    // Previously the missing values were hashed as the string "undefined", producing a header the
+    // device rejected — reported to the user as a bare "Unauthorized /rpc/Shelly.GetStatus", which
+    // is exactly what a wrong password looks like.
+    it('names the malformed challenge instead of hashing an absent realm or nonce', async () => {
+        nock(URL).get('/rpc/Shelly.GetStatus').reply(401, 'Unauthorized', {
+            'www-authenticate': 'Digest qop="auth", algorithm=SHA-256',
+        });
+
+        await assert.rejects(
+            shellyRequestAsync(axios, 'GET', '/rpc/Shelly.GetStatus', null, null, CREDENTIALS),
+            /Malformed digest challenge/
         );
     });
 });


### PR DESCRIPTION
Closes #296.

## The reported bug

Since Shelly firmware 2.0.0, every authenticated RPC call to a gen 2+ device failed with `Unauthorized /rpc/Shelly.GetStatus`, while the same credentials worked from `curl --anyauth`. Reported by @eisenluk, who also diagnosed it and supplied the fix.

Every digest request in `shelly/lib/shelly.js` starts unauthenticated and builds its `Authorization` header from the nonce in the resulting 401 challenge, so the nonce is never reused. The nonce count, however, came from a module-global counter that was pre-incremented per call and shared across every device in the runtime — the first authenticated request after a restart announced `nc=00000002` for a nonce it was using for the first time, and climbed from there.

Firmware 2.0.0 implements RFC 7616 and tracks the count per nonce, so it rejects anything but `00000001`. Earlier firmware ignored the field, which is why this went unnoticed. The counter is gone and `nc` is the constant `00000001`, which is what a fresh nonce means and is equally correct on older firmware.

## The second commit

Reviewing the same handshake surfaced the challenge parser. It split the header on `', '` and each parameter on **every** `=`, keeping field `[1]` — assuming no value contains `=`, that the whitespace after the separating comma is always present, and that no quoted value contains a comma. RFC 7235 guarantees none of those. A base64 nonce was truncated at its padding, and `qop="auth",realm="x"` collapsed into a single token leaving `realm` and `nonce` undefined.

Those undefined values were then hashed as the literal string `undefined`, producing a well-formed but meaningless header. The device answered 401 and the user was told `Unauthorized /rpc/Shelly.GetStatus` — indistinguishable from a wrong password, and identical to what #296 produced. The challenge now goes through a tokenizer that understands quoted strings, and a challenge carrying no realm or nonce raises a named error instead of hashing nothing.

No device in the field was affected by that second issue: current firmware sends a numeric nonce and the conventional `', '` separator. It closes the gap before one is.

## Tests

Seven new tests, all driving real 401 → retry cycles through `shellyRequestAsync` with `nock` rather than poking at internals, so the assertion is about the header that actually reached the device.

- The existing matcher asserted `/nc=[0-9a-f]{8}/`, which `00000002` satisfied as happily as `00000001`; it now matches the literal value.
- A two-request test proves the count does not advance between calls.
- The base64 test recomputes the expected response hash from the captured `cnonce`, so it proves the full nonce reached the hash rather than only the echoed field.

Six of the seven fail against the old code. The seventh pins today's challenge format as a compatibility guard.

Verified locally: lint, format:check, 296 tests, coverage gate.