### PR TITLE
feat!: require Node >= 22.13, drop Node 20 (12.0.0)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [20.x, 22.x]
+                node-version: [22.x, 24.x]
         steps:
             - uses: actions/checkout@v7
             - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [20.x, 22.x]
+                node-version: [22.x, 24.x]
         steps:
             - uses: actions/checkout@v7
             - uses: actions/setup-node@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [12.0.0] - 2026-08-31
+
+### Breaking: Node 20 is no longer supported, the floor is Node 22.13
+
+**If you run Node-RED on Node 20, do not upgrade.** Stay on 11.12.3, which continues to work. npm respects `engines` on install, so Manage Palette will not offer 12.x to you, and nothing breaks by itself.
+
+`engines.node` moves from `>=20.0.0` to `>=22.13.0`. Nothing in the runtime changes: no API, no message contract, no device behaviour. A flow that works on 11.12.3 works unchanged on 12.0.0 given a supported Node. The major bump is purely about the dropped runtime.
+
+The old floor had stopped being true. This package mandates ESLint 10, whose own floor on the 22 line is `^22.13.0` (`^20.19.0 || ^22.13.0 || >=24`), so `>=20.0.0` advertised a range the toolchain would not install on — a contributor on Node 20.0–20.18 got an `EBADENGINE` warning from a floor we had set ourselves. 22.13 also clears `node-red@5`, which needs `>=22.9`.
+
+The immediate trigger was [node-red-standards](https://github.com/windkh/node-red-standards) raising the same floor and enforcing it as a hard audit rule. Because `standards-check` deliberately runs the standard unpinned, every open pull request went red at once without a commit here, and the audit offers no waiver for that rule — `allowDrift` covers file paths only. See [ADR-013](doc/architecture/adr/013-node-22-13-engines-floor.md) for why moving the floor beat changing the shared standard.
+
+CI now runs on `[22.x, 24.x]` instead of `[20.x, 22.x]`, in both the build workflow and the release `verify` job.
+
 ## [11.12.3] - 2026-08-27
 
 ### Digest auth works again on firmware 2.0.0 - [#296](https://github.com/windkh/node-red-contrib-shelly/issues/296)

--- a/doc/architecture/adr/013-node-22-13-engines-floor.md
+++ b/doc/architecture/adr/013-node-22-13-engines-floor.md
@@ -1,0 +1,51 @@
+# 013 — Node 22.13 is the engines floor; Node 20 is dropped in 12.0.0
+
+- **Status:** Accepted
+- **Date:** 2026-08-31
+
+## Context
+
+`engines.node` said `>=20.0.0` from before this repo adopted `node-red-standards`. The standard
+has since raised its own floor to `>=22.13.0` and its `standards-check` audit enforces it as a
+hard rule, so every pull request in this repo went red at once — including four that had nothing
+to do with Node versions. The audit is deliberately unpinned
+(`npx --yes github:windkh/node-red-standards audit`, which its own "Unpinned reference to the
+standard" rule requires), so the failure arrived without any commit here.
+
+The floor is not arbitrary. 22.13.0 is ESLint 10's own floor on the 22 line
+(`^20.19.0 || ^22.13.0 || >=24`), and this repo mandates ESLint 10. Keeping `>=20.0.0` therefore
+advertised a range the toolchain would not actually install on: a contributor on Node 20.0–20.18
+got an `EBADENGINE` warning from a floor we had set ourselves. 22.13 also clears `node-red@5`,
+which needs `>=22.9`.
+
+The audit offers no waiver for this rule. `package.json["node-red-standards"].allowDrift` is a
+set of **file paths** consumed only by the files-drift check, and `severity: 'warn'` is set in
+the standard's source on that one check alone — there is no repo-side setting that downgrades
+the engines rule. Pinning the workflow to an older revision of the standard only trades this
+failure for the unpinned-reference failure. So the choices were to change the shared standard
+for every repo that uses it, or to move this repo's floor.
+
+## Decision
+
+Raise `engines.node` to `>=22.13.0` and release it as **12.0.0**.
+
+Dropping a supported runtime is a breaking change for consumers, and this repo's rules require a
+major bump with an ADR rather than folding it into a patch. It is therefore released on its own
+rather than riding along with the dependency bumps that surfaced it.
+
+The CI matrix moves from `[20.x, 22.x]` to `[22.x, 24.x]` in both `node.js.yml` and the `verify`
+job of `npm-publish.yml`, matching the standard's templates. The publish job stays pinned to
+`22.x`: it satisfies the new floor, and the template's comment warns that resolving a `>=` range
+would put releases on whatever Node major exists that day.
+
+## Consequences
+
+- Node-RED installations on Node 20 cannot upgrade past 11.12.3. Node 20 entered maintenance and
+  some users are still on it, so this is a real cut, not a formality — that is what makes it a
+  major.
+- Manage Palette will not offer 12.x to those users, because npm respects `engines` on install;
+  they stay on 11.12.3, which continues to work.
+- The `EBADENGINE` mismatch between the declared range and what ESLint 10 installs on is gone.
+- `standards-check` goes green, and future pull requests are judged on their own content again.
+- Nothing in the runtime code changes. No API, message contract, or device behaviour is affected;
+  a flow that works on 11.12.3 works unchanged on 12.0.0 given a supported Node.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-shelly",
-    "version": "11.12.3",
+    "version": "12.0.0",
     "description": "Shelly nodes.",
     "node-red": {
         "version": ">=3.0.0",
@@ -9,7 +9,7 @@
         }
     },
     "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
     },
     "keywords": [
         "node-red",


### PR DESCRIPTION
**Breaking change.** `engines.node` moves from `>=20.0.0` to `>=22.13.0`, released as **12.0.0**.

Nothing in the runtime changes — no API, no message contract, no device behaviour. A flow that works on 11.12.3 works unchanged on 12.0.0 given a supported Node. The major bump is purely the dropped runtime.

## Why now

`node-red-standards` raised the same floor and enforces it as a hard audit rule. Because `standards-check.yml` deliberately runs the standard unpinned (`npx --yes github:windkh/node-red-standards audit`, which the standard's own "Unpinned reference to the standard" rule requires), every open PR in this repo went red at once without a commit here — #298, #299, #300 and #301 all failed `standards` on a rule none of them touched.

The rule has no waiver. `package.json["node-red-standards"].allowDrift` is a set of **file paths** consumed only by the files-drift check, and `severity: 'warn'` is set on that one check alone; there is no repo-side setting that downgrades the engines rule. Pinning the workflow to an older revision only trades this failure for the unpinned-reference failure. So the choice was to weaken the shared standard for every repo using it, or to move this repo's floor.

## Why 22.13 specifically

Not arbitrary. It is ESLint 10's own floor on the 22 line (`^20.19.0 || ^22.13.0 || >=24`), and this package mandates ESLint 10 — so `>=20.0.0` was advertising a range the toolchain would not install on. A contributor on Node 20.0–20.18 got an `EBADENGINE` warning from a floor we had set ourselves. 22.13 also clears `node-red@5`, which needs `>=22.9`.

## What users see

**Anyone on Node 20 should stay on 11.12.3**, which continues to work. npm respects `engines` on install, so Manage Palette will not offer 12.x to them — the upgrade doesn't break, it just isn't offered. Node 20 is in maintenance and some Node-RED installs are certainly still on it, which is exactly what makes this a major rather than a patch.

## Changes

- `engines.node`: `>=20.0.0` → `>=22.13.0`; version → `12.0.0`
- CI matrix `[20.x, 22.x]` → `[22.x, 24.x]` in `node.js.yml` and in the `verify` job of `npm-publish.yml`, matching the standard's templates. The publish job stays pinned to `22.x`, which satisfies the new floor.
- [ADR-013](doc/architecture/adr/013-node-22-13-engines-floor.md) records the decision
- CHANGELOG entry leads with the upgrade warning

Local audit goes from 18/19 to **19/19**. Lint, format:check, 296 tests and the coverage gate all pass.